### PR TITLE
Remove log.Fatal call from reader

### DIFF
--- a/sequentialreader.go
+++ b/sequentialreader.go
@@ -146,7 +146,12 @@ func (sr *seqReader) Next() bool {
 		return false
 	}
 	sr.num = num
-	sr.shape = newShape(shapetype)
+	var err error
+	sr.shape, err = newShape(shapetype)
+	if err != nil {
+		sr.err = fmt.Errorf("Error decoding shape type: %v", err)
+		return false
+	}
 	sr.shape.read(er)
 	switch {
 	case er.e == io.EOF:


### PR DESCRIPTION
When an unsupported shape type is encountered, log.Fatal is called. This
is undesirable for a library, as the user should decide when to abort
program execution.

This change modifies newShape to return an error when encountering an
unsupported shape type, and adds a test to verify that reading is
aborted in this case. To facilitate testing, the hard dependency on
os.File in the Reader is replaced with an interface encapsulating all
required methods.