### PR TITLE
Check for field overflow when writing attributes

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -214,6 +214,9 @@ func (w *Writer) WriteAttribute(row int, field int, value interface{}) error {
 	if w.dbf == nil {
 		return errors.New("Initialize DBF by using SetFields first")
 	}
+	if sz := int(w.dbfFields[field].Size); len(buf) > sz {
+		return fmt.Errorf("Unable to write field %v: %q exceeds field length %v", field, buf, sz)
+	}
 
 	seekTo := 1 + int64(w.dbfHeaderLength) + (int64(row) * int64(w.dbfRecordLength))
 	for n := 0; n < field; n++ {

--- a/writer_test.go
+++ b/writer_test.go
@@ -129,9 +129,15 @@ func TestWriteAttribute(t *testing.T) {
 		wantData   string
 	}{
 		{"string-0", 0, 0, "test", 1, "test"},
+		{"string-0-overflow-1", 0, 0, "overflo", 0, ""},
+		{"string-0-overflow-n", 0, 0, "overflowing", 0, ""},
 		{"string-3", 3, 0, "things", 301, "things"},
 		{"float-0", 0, 1, 123.44, 7, "123.4400"},
+		{"float-0-overflow-1", 0, 1, 1234.0, 0, ""},
+		{"float-0-overflow-n", 0, 1, 123456789.0, 0, ""},
 		{"int-0", 0, 2, 4242, 15, "4242"},
+		{"int-0-overflow-1", 0, 2, 42424, 0, ""},
+		{"int-0-overflow-n", 0, 2, 42424343, 0, ""},
 	}
 
 	for _, test := range tests {
@@ -139,13 +145,16 @@ func TestWriteAttribute(t *testing.T) {
 			buf.Reset()
 			s.offset = 0
 
-			w.WriteAttribute(test.row, test.field, test.data)
+			err := w.WriteAttribute(test.row, test.field, test.data)
 
 			if buf.String() != test.wantData {
 				t.Errorf("got data: %v, want: %v", buf.String(), test.wantData)
 			}
 			if s.offset != test.wantOffset {
 				t.Errorf("got seek offset: %v, want: %v", s.offset, test.wantOffset)
+			}
+			if err == nil && test.wantData == "" {
+				t.Error("got no data and no error")
 			}
 		})
 	}


### PR DESCRIPTION
Currently, writing overlong data to fields corrupts data in the
subsequent field(s) or records.

Return an error instead when the size of the data to write exceeds the
available storage space of the field.