### PR TITLE
check for .shp extension when opening file

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -39,12 +40,15 @@ type readSeekCloser interface {
 
 // Open opens a Shapefile for reading.
 func Open(filename string) (*Reader, error) {
-	filename = filename[0 : len(filename)-3]
-	shp, err := os.Open(filename + "shp")
+	ext := filepath.Ext(filename)
+	if strings.ToLower(ext) != ".shp" {
+		return nil, fmt.Errorf("Invalid file extension: %s", filename)
+	}
+	shp, err := os.Open(filename)
 	if err != nil {
 		return nil, err
 	}
-	s := &Reader{filename: filename, shp: shp}
+	s := &Reader{filename: strings.TrimSuffix(filename, ext), shp: shp}
 	s.readHeaders()
 	return s, nil
 }
@@ -190,7 +194,7 @@ func (r *Reader) openDbf() (err error) {
 		return
 	}
 
-	r.dbf, err = os.Open(r.filename + "dbf")
+	r.dbf, err = os.Open(r.filename + ".dbf")
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
I was getting a confusing error when trying to open an invalid file. 

``` go
_, err := shp.Open("foobar")

// 2018/04/23 12:22:36 open fooshp: no such file or directory
```

This change results in the following error message

```
// 2018/04/23 12:23:10 Invalid file extension: foobar
```