### PR TITLE
Symptom: the shape last shape was not being read

### DIFF
--- a/errreader.go
+++ b/errreader.go
@@ -18,7 +18,10 @@ func (er *errReader) Read(p []byte) (n int, err error) {
 	if er.e != nil {
 		return 0, fmt.Errorf("unable to read after previous error: %v", er.e)
 	}
-	n, er.e = er.Reader.Read(p)
+	n, err = er.Reader.Read(p)
+	if n < len(p) && err != nil {
+		er.e = err
+	}
 	er.n += int64(n)
 	return n, er.e
 }


### PR DESCRIPTION
Root Cause:
reader.Next was returning false due to an error being reported in
  r.shape.read(er)
  	 error:  r.err = fmt.Errorf("Error while reading next shape: %v", er.e)

However the error is wrongly reported by errreader.

Go documentation states that an EOF error may be returned even if all the
requested data has been read, but go-shp was treating EOF error as an error
even when all the bytes have been read.

Go documentation: https://go.googlesource.com/go/+/master/src/io/io.go#66

// Callers should always process the n > 0 bytes returned before
// considering the error err. Doing so correctly handles I/O errors
// that happen after reading some bytes and also both of the
// allowed EOF behaviors.

errreader.go was giving priority to the err over the number of bytes being read

Note: This behaviour did not manifest itself in every environment.
Running locally on Ubuntu, the last shape was being read OK
Running on Google App Engine, the last shape was not being read due to this bug