### PR TITLE
Check for errors while reading header

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -67,7 +67,7 @@ func (r *Reader) readHeaders() error {
 	var filelength int32
 	r.shp.Seek(24, 0)
 	// file length
-	binary.Read(r.shp, binary.BigEndian, &filelength)
+	binary.Read(er, binary.BigEndian, &filelength)
 	r.shp.Seek(32, 0)
 	binary.Read(er, binary.LittleEndian, &r.GeometryType)
 	r.bbox.MinX = readFloat64(er)


### PR DESCRIPTION
This change uses the `errReader` wrapper while reading the shapefile header. This is consistent with the way that the header is read for the sequential reader.