### PR TITLE
Check for magic number in headers

### DIFF
--- a/sequentialreader.go
+++ b/sequentialreader.go
@@ -2,6 +2,7 @@ package shp
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -81,7 +82,13 @@ func (sr *seqReader) readHeaders() {
 
 	er := &errReader{Reader: sr.shp}
 	// shp headers
-	io.CopyN(ioutil.Discard, er, 24)
+	var magic int32
+	binary.Read(er, binary.BigEndian, &magic)
+	if er.e == nil && magic != 9994 {
+		er.e = errors.New("File signature doesn't match shapefile")
+		return
+	}
+	io.CopyN(ioutil.Discard, er, 20)
 	var l int32
 	binary.Read(er, binary.BigEndian, &l)
 	sr.filelength = int64(l) * 2


### PR DESCRIPTION
This change checks for the magic number 9994 in the first 4 bytes of the header as per the shapefile spec (https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf). This is useful for detecting a non-shapefile being parsed as though it were a shapefile.