### PR TITLE
fix shape overreading bug

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -498,8 +498,8 @@ func newReadSeekCloser(b []byte) readSeekCloser {
 
 func TestReadInvalidShapeType(t *testing.T) {
 	record := []byte{
-		0, 0, 0, 0,
-		0, 0, 0, 0,
+		0, 0, 0, 1,
+		0, 0, 0, 2,
 		255, 255, 255, 255, // shape type
 	}
 


### PR DESCRIPTION
I discovered this bug when attempting to read Shapefiles which contained PointZ records with no M value.

This fix has not been tested for all of the various Shape types which possess optional values, just the PointZ case, but at a glance it appears that the various shape.Read() implementations should do the right thing with the fix in place, and it will prevent Next() from getting out of sync with the records.